### PR TITLE
Add Cancel function; add finalizer to cleanup abandoned batch

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -3,6 +3,7 @@ package badger
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -392,11 +393,6 @@ func (d *Datastore) Close() error {
 
 // Batch creats a new Batch object. This provides a way to do many writes, when
 // there may be too many to fit into a single transaction.
-//
-// After writing to a Batch, always call Commit whether or not writing to the
-// batch was completed successfully or not.  This is necessary to flush any
-// remaining data and free any resources associated with an incomplete
-// transaction.
 func (d *Datastore) Batch() (ds.Batch, error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
@@ -404,7 +400,12 @@ func (d *Datastore) Batch() (ds.Batch, error) {
 		return nil, ErrClosed
 	}
 
-	return &batch{d, d.DB.NewWriteBatch()}, nil
+	b := &batch{d, d.DB.NewWriteBatch()}
+	// Ensure that incomplete transaction resources are cleaned up in case
+	// batch is abandoned.
+	runtime.SetFinalizer(b, func(b *batch) { b.cancel() })
+
+	return b, nil
 }
 
 func (d *Datastore) CollectGarbage() (err error) {
@@ -473,9 +474,24 @@ func (b *batch) commit() error {
 	err := b.writeBatch.Flush()
 	if err != nil {
 		// Discard incomplete transaction held by b.writeBatch
-		b.writeBatch.Cancel()
+		b.cancel()
 	}
 	return err
+}
+
+func (b *batch) Cancel() error {
+	b.ds.closeLk.RLock()
+	defer b.ds.closeLk.RUnlock()
+	if b.ds.closed {
+		return ErrClosed
+	}
+
+	b.cancel()
+	return nil
+}
+
+func (b *batch) cancel() {
+	b.writeBatch.Cancel()
 }
 
 var _ ds.Datastore = (*txn)(nil)

--- a/ds_test.go
+++ b/ds_test.go
@@ -322,7 +322,10 @@ func TestBatching(t *testing.T) {
 	}
 
 	// TODO: remove type assertion once datastore.Batch interface has Cancel
-	b.(*batch).Cancel()
+	err = b.(*batch).Cancel()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = d.Get(ds.NewKey(key))
 	if err == nil {

--- a/ds_test.go
+++ b/ds_test.go
@@ -307,6 +307,27 @@ func TestBatching(t *testing.T) {
 		"/g",
 	}, rs)
 
+	//Test cancel
+
+	b, err = d.Batch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const key = "/xyz"
+
+	err = b.Put(ds.NewKey(key), []byte("/x/y/z"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: remove type assertion once datastore.Batch interface has Cancel
+	b.(*batch).Cancel()
+
+	_, err = d.Get(ds.NewKey(key))
+	if err == nil {
+		t.Fatal("expected error trying to get uncommited data")
+	}
 }
 
 func TestBatchingRequired(t *testing.T) {


### PR DESCRIPTION
This will allow a `Cancel` to be added to the `datastore.Batch` interface at a later time