### PR TITLE
Add default TTL option

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -35,6 +35,7 @@ type Datastore struct {
 	gcInterval     time.Duration
 
 	syncWrites bool
+	ttl        time.Duration
 }
 
 // Implements the datastore.Batch interface, enabling batching support for
@@ -71,11 +72,68 @@ type Options struct {
 	// GcInterval.
 	GcSleep time.Duration
 
+	// TTL sets the expiration time for all newly added blocks. After expiration,
+	// the blocks will no longer be retrievable and will be removed by garbage
+	// collection.
+	//
+	// The default value is 0, which means no TTL.
+	TTL time.Duration
+
 	badger.Options
 }
 
 // DefaultOptions are the default options for the badger datastore.
 var DefaultOptions Options
+
+func DefaultOpts() Options {
+	opts := DefaultOptions
+	return opts
+}
+
+// WithGcDiscardRatio returns a new Options value with GcDiscardRatio set to the given value.
+//
+// Please refer to the Badger docs to see what this is for
+//
+// Default value is 0.2
+func (opt Options) WithGcDiscardRatio(ratio float64) Options {
+	opt.GcDiscardRatio = ratio
+	return opt
+}
+
+// WithGcInterval returns a new Options value with GcInterval set to the given
+// value.
+//
+// GcInterval specifies the interval between garbage collection cycles. If zero,
+// the datastore will perform no automatic garbage collection.
+//
+// Default value is 15 minutes.
+func (opt Options) WithGcInterval(interval time.Duration) Options {
+	opt.GcInterval = interval
+	return opt
+}
+
+// WithGcSleep returns a new Options value with GcSleep set to the given value.
+//
+// GcSleep specifies the sleep time between rounds of a single garbage collection
+// cycle. If zero, the datastore will only perform one round of GC per GcInterval.
+//
+// Default value is 10 seconds.
+func (opt Options) WithGcSleep(sleep time.Duration) Options {
+	opt.GcSleep = sleep
+	return opt
+}
+
+// WithTTL returns a new Options value with TTL set to the given value.
+//
+// TTL sets the expiration time for all newly added blocks. After expiration,
+// the blocks will no longer be retrievable and will be removed by garbage
+// collection.
+//
+// Default value is 0, which means no TTL.
+func (opt Options) WithTTL(ttl time.Duration) Options {
+	opt.TTL = ttl
+	return opt
+}
 
 func init() {
 	DefaultOptions = Options{
@@ -123,16 +181,19 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 	var gcDiscardRatio float64
 	var gcSleep time.Duration
 	var gcInterval time.Duration
+	var ttl time.Duration
 	if options == nil {
 		opt = DefaultOptions.Options
 		gcDiscardRatio = DefaultOptions.GcDiscardRatio
 		gcSleep = DefaultOptions.GcSleep
 		gcInterval = DefaultOptions.GcInterval
+		ttl = DefaultOptions.TTL
 	} else {
 		opt = options.Options
 		gcDiscardRatio = options.GcDiscardRatio
 		gcSleep = options.GcSleep
 		gcInterval = options.GcInterval
+		ttl = options.TTL
 	}
 
 	if gcSleep <= 0 {
@@ -163,6 +224,7 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 		gcSleep:        gcSleep,
 		gcInterval:     gcInterval,
 		syncWrites:     opt.SyncWrites,
+		ttl:            ttl,
 	}
 
 	// Start the GC process if requested.
@@ -231,8 +293,14 @@ func (d *Datastore) Put(ctx context.Context, key ds.Key, value []byte) error {
 	txn := d.newImplicitTransaction(false)
 	defer txn.discard()
 
-	if err := txn.put(key, value); err != nil {
-		return err
+	if d.ttl > 0 {
+		if err := txn.putWithTTL(key, value, d.ttl); err != nil {
+			return err
+		}
+	} else {
+		if err := txn.put(key, value); err != nil {
+			return err
+		}
 	}
 
 	return txn.commit()
@@ -443,11 +511,20 @@ func (b *batch) Put(ctx context.Context, key ds.Key, value []byte) error {
 	if b.ds.closed {
 		return ErrClosed
 	}
+
+	if b.ds.ttl > 0 {
+		return b.putWithTTL(key, value, b.ds.ttl)
+	}
+
 	return b.put(key, value)
 }
 
 func (b *batch) put(key ds.Key, value []byte) error {
 	return b.writeBatch.Set(key.Bytes(), value)
+}
+
+func (b *batch) putWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
+	return b.writeBatch.SetEntry(badger.NewEntry(key.Bytes(), value).WithTTL(ttl))
 }
 
 func (b *batch) Delete(ctx context.Context, key ds.Key) error {
@@ -510,6 +587,11 @@ func (t *txn) Put(ctx context.Context, key ds.Key, value []byte) error {
 	if t.ds.closed {
 		return ErrClosed
 	}
+
+	if t.ds.ttl > 0 {
+		return t.putWithTTL(key, value, t.ds.ttl)
+	}
+
 	return t.put(key, value)
 }
 

--- a/datastore.go
+++ b/datastore.go
@@ -85,11 +85,6 @@ type Options struct {
 // DefaultOptions are the default options for the badger datastore.
 var DefaultOptions Options
 
-func DefaultOpts() Options {
-	opts := DefaultOptions
-	return opts
-}
-
 // WithGcDiscardRatio returns a new Options value with GcDiscardRatio set to the given value.
 //
 // Please refer to the Badger docs to see what this is for

--- a/datastore.go
+++ b/datastore.go
@@ -72,8 +72,8 @@ type Options struct {
 	// GcInterval.
 	GcSleep time.Duration
 
-	// TTL sets the expiration time for all newly added blocks. After expiration,
-	// the blocks will no longer be retrievable and will be removed by garbage
+	// TTL sets the expiration time for all newly added keys. After expiration,
+	// the keys will no longer be retrievable and will be removed by garbage
 	// collection.
 	//
 	// The default value is 0, which means no TTL.
@@ -125,8 +125,8 @@ func (opt Options) WithGcSleep(sleep time.Duration) Options {
 
 // WithTTL returns a new Options value with TTL set to the given value.
 //
-// TTL sets the expiration time for all newly added blocks. After expiration,
-// the blocks will no longer be retrievable and will be removed by garbage
+// TTL sets the expiration time for all newly added keys. After expiration,
+// the keys will no longer be retrievable and will be removed by garbage
 // collection.
 //
 // Default value is 0, which means no TTL.

--- a/ds_test.go
+++ b/ds_test.go
@@ -341,7 +341,7 @@ func TestBatching(t *testing.T) {
 
 	// Test with TTL
 
-	opts := DefaultOpts().WithTTL(time.Second)
+	opts := DefaultOptions.WithTTL(time.Second)
 	d, done = newDS(t, &opts)
 	defer done()
 
@@ -1013,16 +1013,19 @@ func TestOptions(t *testing.T) {
 	interval := 2 * time.Second
 	sleep := 3 * time.Second
 	ttl := 4 * time.Second
-	o := DefaultOpts().
+	o := DefaultOptions.
+		WithTTL(ttl).
 		WithGcDiscardRatio(ratio).
 		WithGcInterval(interval).
-		WithGcSleep(sleep).
-		WithTTL(ttl)
+		WithGcSleep(sleep)
 
+	assert.Equal(t, ttl, o.TTL)
 	assert.Equal(t, ratio, o.GcDiscardRatio)
 	assert.Equal(t, interval, o.GcInterval)
 	assert.Equal(t, sleep, o.GcSleep)
-	assert.Equal(t, ttl, o.TTL)
+
+	// Make sure DefaultOptions aren't changed
+	assert.Equal(t, time.Duration(0), DefaultOptions.TTL)
 }
 
 func TestClosedError(t *testing.T) {
@@ -1184,7 +1187,7 @@ func TestClosedError(t *testing.T) {
 }
 
 func TestDefaultTTL(t *testing.T) {
-	opts := DefaultOpts().WithTTL(time.Second)
+	opts := DefaultOptions.WithTTL(time.Second)
 	d, done := newDS(t, &opts)
 	defer done()
 

--- a/ds_test.go
+++ b/ds_test.go
@@ -345,26 +345,26 @@ func TestBatching(t *testing.T) {
 	d, done = newDS(t, &opts)
 	defer done()
 
-	b, err = d.Batch()
+	b, err = d.Batch(bg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for k, v := range testcases {
-		err := b.Put(ds.NewKey(k), []byte(v))
+		err := b.Put(bg, ds.NewKey(k), []byte(v))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	err = b.Commit()
+	err = b.Commit(bg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check data was set correctly
 	for k, v := range testcases {
-		val, err := d.Get(ds.NewKey(k))
+		val, err := d.Get(bg, ds.NewKey(k))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -378,7 +378,7 @@ func TestBatching(t *testing.T) {
 
 	// check data has expired
 	for k := range testcases {
-		has, err := d.Has(ds.NewKey(k))
+		has, err := d.Has(bg, ds.NewKey(k))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1202,30 +1202,30 @@ func TestDefaultTTL(t *testing.T) {
 
 	// put directly into datastore
 	for key, bytes := range data1 {
-		err := d.Put(key, bytes)
+		err := d.Put(bg, key, bytes)
 		assert.NoError(t, err)
 	}
 
 	// put via transactions
 	for key, bytes := range data2 {
-		tx, err := d.NewTransaction(false)
+		tx, err := d.NewTransaction(bg, false)
 		assert.NoError(t, err)
 
-		err = tx.Put(key, bytes)
+		err = tx.Put(bg, key, bytes)
 		assert.NoError(t, err)
 
-		err = tx.Commit()
+		err = tx.Commit(bg)
 		assert.NoError(t, err)
 	}
 
 	// check data was persisted
 	for key := range data1 {
-		has, err := d.Has(key)
+		has, err := d.Has(bg, key)
 		assert.NoError(t, err)
 		assert.True(t, has, "record not in db")
 	}
 	for key := range data2 {
-		has, err := d.Has(key)
+		has, err := d.Has(bg, key)
 		assert.NoError(t, err)
 		assert.True(t, has, "record not in db")
 	}
@@ -1234,14 +1234,14 @@ func TestDefaultTTL(t *testing.T) {
 
 	// check datastore data has expired
 	for key := range data1 {
-		has, err := d.Has(key)
+		has, err := d.Has(bg, key)
 		assert.NoError(t, err)
 		assert.False(t, has, "record with ttl did not expire")
 	}
 
 	// check txn data has expired
 	for key := range data2 {
-		has, err := d.Has(key)
+		has, err := d.Has(bg, key)
 		assert.NoError(t, err)
 		assert.False(t, has, "record with ttl did not expire")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ipfs/go-detect-race v0.0.1
 	github.com/ipfs/go-log/v2 v2.1.1
 	github.com/jbenet/goprocess v0.1.4
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,9 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
@@ -114,5 +115,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=


### PR DESCRIPTION
This PR adds an option to specify a default TTL for all puts. When set, all `Put` operations on the `datastore`, `batch`, and `txn` objects will include the configured default expiration set on the underlying entry. Calls to `PutWithTTL` are unchanged.

This also includes `With*` config methods similar to badger's options chaining methods for consistency.