### PR TITLE
Fix flakey Default TTL tests

### DIFF
--- a/ds_test.go
+++ b/ds_test.go
@@ -1207,6 +1207,11 @@ func TestDefaultTTL(t *testing.T) {
 	for key, bytes := range data1 {
 		err := d.Put(bg, key, bytes)
 		assert.NoError(t, err)
+
+		// check data was persisted
+		has, err := d.Has(bg, key)
+		assert.NoError(t, err)
+		assert.True(t, has, "record not in db")
 	}
 
 	// put via transactions
@@ -1219,15 +1224,8 @@ func TestDefaultTTL(t *testing.T) {
 
 		err = tx.Commit(bg)
 		assert.NoError(t, err)
-	}
 
-	// check data was persisted
-	for key := range data1 {
-		has, err := d.Has(bg, key)
-		assert.NoError(t, err)
-		assert.True(t, has, "record not in db")
-	}
-	for key := range data2 {
+		// check data was persisted
 		has, err := d.Has(bg, key)
 		assert.NoError(t, err)
 		assert.True(t, has, "record not in db")


### PR DESCRIPTION
This fixes the `TestDefaultTTL` test, which was flakey in CI. It failed when setting up the test keys took longer than the 1 second TTL. Fixed (hopefully) by doing the initial check immediately instead of after setting up all entries.

Example failure: https://github.com/ipfs/go-ds-badger2/runs/4586674243?check_suite_focus=true